### PR TITLE
表に削除ボタンの追加、削除を押した行と同じデータをLocalstorageから削除を実装

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,3 +6,4 @@ table, th, td{
 table {
     border-collapse: collapse;
   }
+  

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,8 @@
+table, th, td{
+    border: 1px solid black;
+    padding: 5px 20px;
+}
+
+table {
+    border-collapse: collapse;
+  }

--- a/index.html
+++ b/index.html
@@ -26,21 +26,11 @@
           <tr>
             <td>単語</td>
             <td>役</td>
-            <td><button type="button">削除</button></td>
+            <td></td>
           </tr>
         </tbody>
       </table>
     </div>
-    <<div id="displayLs"></div>
-    <button type="button" onclick="showData()">データ参照</button>
-    <button type="button" onclick="viewData()">データ参照</button>
-    <button type="button" onclick="deleteData()">リストを削除</button>
-    <h2>保有するデータを1件ランダム表示</h2>
-    <button type="button" onclick="randomData()">LSをランダム表示</button>
-    <div id="randomLs"></div>
-    <h2>ランダムに数字0-9を表示</h2>
-    <button type="button" onclick="randomNumber()">数字をランダム表示</button>
-    <div id="randomDisplay"></div>
     <h2>保有する件数をページ読み込み時に自動で表示</h2>
     <div id="countLs"></div>
   </div>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <tbody id="tableLs">
           <tr>
             <td>単語</td>
-            <td>役</td>
+            <td>訳</td>
             <td></td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -20,8 +20,20 @@
       <button type="button" onclick="dumpLsdata()">LS内に保存されている全ての値を消去</button>
     </form>
     <h2>保有するデータを全て表示</h2>
-    <div id="displayLs"></div>
+    <div>
+      <table>
+        <tbody id="tableLs">
+          <tr>
+            <td>単語</td>
+            <td>役</td>
+            <td><button type="button">削除</button></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <<div id="displayLs"></div>
     <button type="button" onclick="showData()">データ参照</button>
+    <button type="button" onclick="viewData()">データ参照</button>
     <button type="button" onclick="deleteData()">リストを削除</button>
     <h2>保有するデータを1件ランダム表示</h2>
     <button type="button" onclick="randomData()">LSをランダム表示</button>

--- a/js/index.js
+++ b/js/index.js
@@ -6,7 +6,7 @@ window.onload = firstFunction;
 function firstFunction() {
 
   Object.keys(localStorage).forEach(function(key){
-  var d = JSON.parse(localStorage.getItem(key));
+  const d = JSON.parse(localStorage.getItem(key));
     document.getElementById("tableLs").insertAdjacentHTML("beforeend",
       `<tr id="${key}">
         <td>${d.word}</td>
@@ -22,25 +22,25 @@ function firstFunction() {
 // 単語のセットを定義
 function pushData(){
   //入力されたデータを取得
-  var nu = document.getElementById("num").value;
-  var wo = document.getElementById("word").value;
-  var de = document.getElementById("description").value;
+  let nu = document.getElementById("num").value;
+  let wo = document.getElementById("word").value;
+  let de = document.getElementById("description").value;
 
   //データをオブジェクトに保存する
-  var array = [];
-  var flashcards = {
+  let array = [];
+  let flashcards = {
       word: wo,
       desc: de
   }
   array.push(flashcards);
   //JSONデータに変換して登録する
-  var setjson = JSON.stringify(flashcards);
+  const setjson = JSON.stringify(flashcards);
   localStorage.setItem(nu, setjson);
 };　
 
 // 削除ボタンを押すと表示されている列とLocalstorageの両方を削除
-function deleteLsData(AAA) {
-  const rows = AAA.parentNode.parentNode;  // 削除ボタンを押された行のtr行を選択
+function deleteLsData(pushedDeleteButton) {
+  const rows = pushedDeleteButton.parentNode.parentNode;  // 削除ボタンを押された行のtr行を選択
   const pickTrId = rows.getAttribute("id");  // rowsで取得した行のidを取得
   localStorage.removeItem(pickTrId);  // localstorageからidと同名のキーを削除
   rows.parentNode.deleteRow(rows.sectionRowIndex);  // rowsでtbody内の行番号を指定して削除

--- a/js/index.js
+++ b/js/index.js
@@ -27,10 +27,23 @@ function pushData(){
 
 // displayLsのテキストを削除
 function deleteData(){
-  document.getElementById("displayLs").textContent = "";
+  document.getElementById("tableLs").textContent = "";
 };
 
 // Localstorage内のデータを全て表示
+function viewData() {
+//  document.getElementById("tableLs").textContent = ""; //初期化
+  Object.keys(localStorage).forEach(function(key){
+  var d = JSON.parse(localStorage.getItem(key));
+  //document.getElementById("tableLs").insertAdjacentHTML("afterbegin", `キー：${key}　 ワード：${d.word}　翻訳：${d.desc} <br>`);
+  document.getElementById("tableLs").insertAdjacentHTML("afterbegin", `<tr id="${key}"><td>${d.word}</td><td>${d.desc}</td><td><button type="button">削除</button></td></tr>`);
+  });
+};
+
+function deleteRow() {
+  // この行を削除する処理を追加。 removeRow(this)_?
+};
+// Localstorage内のデータを全て表示（旧）
 function showData() {
   document.getElementById("displayLs").textContent = "";
   Object.keys(localStorage).forEach(function(key) {
@@ -39,6 +52,7 @@ function showData() {
   });
 };
 
+
 // Localstorageからランダムで1件を表示
 function randomData() {
   const v = localStorage.length;
@@ -46,13 +60,15 @@ function randomData() {
     alert("LocalStorageにデータがありません");
   } else {
       document.getElementById("randomLs").textContent = "";
-      let lengthLs = localStorage.length;
-      let ranNum = Math.floor(Math.random() * lengthLs); // 最大数からランダムで
-      let nl = localStorage.key(ranNum);
-      let lsg = JSON.parse(window.localStorage.getItem(nl));
+      const lengthLs = localStorage.length;
+      const ranNum = Math.floor(Math.random() * lengthLs); // 最大数からランダムで
+      const nl = localStorage.key(ranNum);
+      const lsg = JSON.parse(window.localStorage.getItem(nl));
       document.getElementById("randomLs").insertAdjacentHTML("afterbegin", `ワード：${lsg.word}　翻訳：${lsg.desc} <br>`); 
   }
 };
+
+
 
 // ランダムに数字を表示
 function randomNumber() {

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
 "use strict";
 // 起動時に以下を実行
-window.onload = firstScript;
+window.onload = viewData;
 function firstScript() {
   let lengthLs = localStorage.length;
   document.getElementById("countLs").innerHTML = lengthLs;
@@ -25,55 +25,26 @@ function pushData(){
   localStorage.setItem(nu, setjson);
 };　
 
-// displayLsのテキストを削除
-function deleteData(){
-  document.getElementById("tableLs").textContent = "";
-};
-
 // Localstorage内のデータを全て表示
 function viewData() {
 //  document.getElementById("tableLs").textContent = ""; //初期化
   Object.keys(localStorage).forEach(function(key){
   var d = JSON.parse(localStorage.getItem(key));
   //document.getElementById("tableLs").insertAdjacentHTML("afterbegin", `キー：${key}　 ワード：${d.word}　翻訳：${d.desc} <br>`);
-  document.getElementById("tableLs").insertAdjacentHTML("afterbegin", `<tr id="${key}"><td>${d.word}</td><td>${d.desc}</td><td><button type="button">削除</button></td></tr>`);
+    document.getElementById("tableLs").insertAdjacentHTML("beforeend",
+      `<tr id="${key}">
+        <td>${d.word}</td>
+        <td>${d.desc}</td>
+        <td><button type="button" onclick="deleteRow(this)">削除</button></td>
+      </tr>`);
   });
 };
 
-function deleteRow() {
-  // この行を削除する処理を追加。 removeRow(this)_?
-};
-// Localstorage内のデータを全て表示（旧）
-function showData() {
-  document.getElementById("displayLs").textContent = "";
-  Object.keys(localStorage).forEach(function(key) {
-    var d = JSON.parse(window.localStorage.getItem(key));
-    document.getElementById("displayLs").insertAdjacentHTML("afterbegin", `キー：${key}　 ワード：${d.word}　翻訳：${d.desc} <br>`);
-  });
-};
-
-
-// Localstorageからランダムで1件を表示
-function randomData() {
-  const v = localStorage.length;
-  if (v == "") {
-    alert("LocalStorageにデータがありません");
-  } else {
-      document.getElementById("randomLs").textContent = "";
-      const lengthLs = localStorage.length;
-      const ranNum = Math.floor(Math.random() * lengthLs); // 最大数からランダムで
-      const nl = localStorage.key(ranNum);
-      const lsg = JSON.parse(window.localStorage.getItem(nl));
-      document.getElementById("randomLs").insertAdjacentHTML("afterbegin", `ワード：${lsg.word}　翻訳：${lsg.desc} <br>`); 
-  }
-};
-
-
-
-// ランダムに数字を表示
-function randomNumber() {
-  let ranNum = Math.floor(Math.random() * 10);
-  document.getElementById("randomDisplay").innerHTML = ranNum;
+function deleteRow(obj) {
+  // 削除ボタンを押下された行を取得
+  const tr = obj.parentNode.parentNode;
+  // trのインデックスを取得して行を削除する
+  tr.parentNode.deleteRow(tr.sectionRowIndex);
 };
 
 //LocalStorage内のデータを全て破棄する

--- a/js/index.js
+++ b/js/index.js
@@ -1,9 +1,22 @@
 "use strict";
 // 起動時に以下を実行
-window.onload = viewData;
-function firstScript() {
-  let lengthLs = localStorage.length;
-  document.getElementById("countLs").innerHTML = lengthLs;
+window.onload = firstFunction;
+
+// Localstorage内のデータを全て表示
+function firstFunction() {
+
+  Object.keys(localStorage).forEach(function(key){
+  var d = JSON.parse(localStorage.getItem(key));
+    document.getElementById("tableLs").insertAdjacentHTML("beforeend",
+      `<tr id="${key}">
+        <td>${d.word}</td>
+        <td>${d.desc}</td>
+        <td><button type="button" onclick="deleteLsData(this)">削除</button></td>
+      </tr>`);
+  });
+    //  LocalStorageが保有する件数を表示
+    let lengthLs = localStorage.length;
+    document.getElementById("countLs").innerHTML = lengthLs;
 };
 
 // 単語のセットを定義
@@ -25,26 +38,12 @@ function pushData(){
   localStorage.setItem(nu, setjson);
 };　
 
-// Localstorage内のデータを全て表示
-function viewData() {
-//  document.getElementById("tableLs").textContent = ""; //初期化
-  Object.keys(localStorage).forEach(function(key){
-  var d = JSON.parse(localStorage.getItem(key));
-  //document.getElementById("tableLs").insertAdjacentHTML("afterbegin", `キー：${key}　 ワード：${d.word}　翻訳：${d.desc} <br>`);
-    document.getElementById("tableLs").insertAdjacentHTML("beforeend",
-      `<tr id="${key}">
-        <td>${d.word}</td>
-        <td>${d.desc}</td>
-        <td><button type="button" onclick="deleteRow(this)">削除</button></td>
-      </tr>`);
-  });
-};
-
-function deleteRow(obj) {
-  // 削除ボタンを押下された行を取得
-  const tr = obj.parentNode.parentNode;
-  // trのインデックスを取得して行を削除する
-  tr.parentNode.deleteRow(tr.sectionRowIndex);
+// 削除ボタンを押すと表示されている列とLocalstorageの両方を削除
+function deleteLsData(AAA) {
+  const rows = AAA.parentNode.parentNode;  // 削除ボタンを押された行のtr行を選択
+  const pickTrId = rows.getAttribute("id");  // rowsで取得した行のidを取得
+  localStorage.removeItem(pickTrId);  // localstorageからidと同名のキーを削除
+  rows.parentNode.deleteRow(rows.sectionRowIndex);  // rowsでtbody内の行番号を指定して削除
 };
 
 //LocalStorage内のデータを全て破棄する


### PR DESCRIPTION
表題の通り。
削除列の取得の仕方はとりあえずSlackで質問したままの実装。

ページ読み込み時にリストを全件表示しているので
表示上の削除よりLocalStorageから再読み出しをするほうがいいかもしれないが
ひとまず思い通りの動きをしているのでプルリク。
